### PR TITLE
Add image to pokemon recycler view.

### DIFF
--- a/app/src/main/java/com/example/pokedex/PokemonInfoActivity.kt
+++ b/app/src/main/java/com/example/pokedex/PokemonInfoActivity.kt
@@ -35,7 +35,7 @@ class PokemonInfoActivity : AppCompatActivity() {
         pokemonInfoViewModel.pokemon.observe(this) { pokemon ->
             pokemon?.let {
                 detailBinding.pokemon = it
-                loadPokemonImage(it.sprites.frontShiny)
+                loadPokemonImage(it.sprites.other.officialArtwork.frontShiny)
             }
         }
         pokemonInfoViewModel.errorMessage.observe(this) { errorMessage ->

--- a/app/src/main/java/com/example/pokedex/network/models/Pokemon.kt
+++ b/app/src/main/java/com/example/pokedex/network/models/Pokemon.kt
@@ -7,5 +7,5 @@ data class Pokemon(
     val height: Int,
     val abilities: List<Abilities>,
     val types: List<Types>,
-    val imageUrl: String
+    var imageUrl: String
 )

--- a/app/src/main/java/com/example/pokedex/network/models/PokemonInfoResponse.kt
+++ b/app/src/main/java/com/example/pokedex/network/models/PokemonInfoResponse.kt
@@ -29,5 +29,13 @@ data class Type(
 )
 
 data class Sprites(
+    @SerializedName("other") val other: OtherSprites
+)
+
+data class OtherSprites(
+    @SerializedName("official-artwork") val officialArtwork: OfficialArtwork
+)
+
+data class OfficialArtwork(
     @SerializedName("front_shiny") val frontShiny: String
 )

--- a/app/src/main/java/com/example/pokedex/pokemon/PokemonViewHolder.kt
+++ b/app/src/main/java/com/example/pokedex/pokemon/PokemonViewHolder.kt
@@ -2,6 +2,7 @@ package com.example.pokedex.pokemon
 
 import android.content.Intent
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.bumptech.glide.Glide
 import com.example.pokedex.PokemonInfoActivity
 import com.example.pokedex.databinding.ItemPokemonListBinding
 import com.example.pokedex.network.models.Pokemon
@@ -16,6 +17,9 @@ class PokemonViewHolder(private val binding: ItemPokemonListBinding) : ViewHolde
                 intent.putExtra(Constants.POKEMON_NAME, pokemon.name)
                 root.context.startActivity(intent)
             }
+            Glide.with(root)
+                .load(pokemon.imageUrl)
+                .into(imageViewPokemon)
         }
         binding.executePendingBindings()
     }

--- a/app/src/main/res/layout/item_pokemon_list.xml
+++ b/app/src/main/res/layout/item_pokemon_list.xml
@@ -24,6 +24,7 @@
             tools:ignore="UseCompoundDrawables">
 
             <ImageView
+                android:id="@+id/image_view_pokemon"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"


### PR DESCRIPTION
### Description:

This pull request adds image loading functionality to the RecyclerView elements in the Pokemon list, enhancing the visual experience for users.

### Changes:

- Implemented Glide library in PokemonViewHolder class to load Pokemon images efficiently.
- Updated item_pokemon_list.xml layout to accommodate Pokemon images within the list items.